### PR TITLE
Use signatory-client-lib 1.0.5

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "signatory-client-lib"
-version = "0.2.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23b8cf6bec9ccd55239ed8fa5502ae2fd8c7ceef2d2e6173cf699483457b2c3"
+checksum = "f3afc7495b2c7e479365f7aec4e7bb6b9127629b0d00cae48b05ee954e2e1396"
 dependencies = [
  "base64",
  "bs58",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,7 +15,7 @@ rand = { version = "0.7.0", features = ["getrandom", "std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9.22"
-signatory-client-lib = "0.2.0"
+signatory-client-lib = "1.0.5"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.4.1", features = ["cors", "request-id", "trace"] }
 tracing = "0.1.37"


### PR DESCRIPTION
Fixes parsing of sendQty and maxSendQty. Previously, they needed to parse as `u64`. Now, they must parse as `u128`. `u64` was too small for many quantities on EVM chains, which are often scaled with 18 decimals.